### PR TITLE
Remove Spark Plugin and components from autoload paths.

### DIFF
--- a/lib/spark_engine/plugin.rb
+++ b/lib/spark_engine/plugin.rb
@@ -58,12 +58,6 @@ module SparkEngine
 
       end)
 
-      # Autoload engine lib and components path
-      @engine.config.autoload_paths.concat [
-        File.join(@engine.spark_plugin_path, "lib"),
-        SparkEngine.plugin.paths[:components]
-      ]
-
       @engine.config.after_initialize do |app|
         if defined?(SassC) && defined?(SassC::Rails)
           # Inject Sass importer for yaml files


### PR DESCRIPTION
* Adding paths to autoload_paths is discouraged in Rails > 5. You only need to autoload paths that would occur outside of a normal file structure. Since Spark is a Rails Engine, everything in app/ is already autoloaded.

* The motivation for this change is to make this gem compatible with the Zeitwerk autoloader, which is much stricter about constant autoloading